### PR TITLE
Fix wrong link to `attack_usts.py` in README 🔨

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ By Tianyu Gu, Brendan Dolan-Gavitt, Siddharth Garg
     ```
     Go [here](http://cvrr.ucsd.edu/vivachallenge/index.php/signs/sign-detection/) for more information about the usts dataset.
 
-4. Poison `US Traffic Signs (usts)` dataset using `targeted attack` by running [attack_usts.py](https://github.com/Kooscii/BadNets/blob/master/datasets/fetch_usts.py) with 'targeted' argument.
+4. Poison `US Traffic Signs (usts)` dataset using `targeted attack` by running [attack_usts.py](https://github.com/Kooscii/BadNets/blob/master/datasets/attack_usts.py) with 'targeted' argument.
     ```Shell
     cd $BadNets/datasets
     python attack_usts.py targeted

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By Tianyu Gu, Brendan Dolan-Gavitt, Siddharth Garg
     python attack_usts.py targeted
     ```
 
-5. Poison `US Traffic Signs (usts)` dataset using `random attack` by running [attack_usts.py](https://github.com/Kooscii/BadNets/blob/master/datasets/fetch_usts.py) with 'random' argument.
+5. Poison `US Traffic Signs (usts)` dataset using `random attack` by running [attack_usts.py](https://github.com/Kooscii/BadNets/blob/master/datasets/attack_usts.py) with 'random' argument.
     ```Shell
     cd $BadNets/datasets
     python attack_usts.py random


### PR DESCRIPTION
Link should point to `attack_usts.py` but instead links to `fetch_usts.py`. This commit fixes this minor typo.